### PR TITLE
parse.js: update to working URL, add github project URL

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -1,7 +1,8 @@
 // parse.js
 // Parser for Simplified JavaScript written in Simplified JavaScript
 // From Top Down Operator Precedence
-// http://javascript.crockford.com/tdop/index.html
+// http://crockford.com/javascript/tdop/tdop.html
+// https://github.com/douglascrockford/TDOP
 // Douglas Crockford
 // 2016-02-15
 


### PR DESCRIPTION
The URL in parse.js: // http://javascript.crockford.com/tdop/index.html
and in the github project "about box": http://javascript.crockford.com/tdop/tdop.html
redirect to http://crockford.com/javascript/

Feel free to discard this if you like (or want to fix the URL redirection) instead.
Phil

